### PR TITLE
Added tests to verify Terraform arguments are working

### DIFF
--- a/tests/installed-correctly-global.test.js
+++ b/tests/installed-correctly-global.test.js
@@ -4,15 +4,33 @@ function showError(msg) {
 	console.error(`Test 'global' failed: ${msg}`);
 }
 
-exec('terraform -v', function(err, stdout, stderr) {
-	if (err || stderr) {
-		showError(err || stderr);
-		process.exit(1);
+function handleDoubleErrorSource(a, b, code) {
+	if (a || b) {
+		showError(a || b);
+		process.exit(code);
 	}
-	if (stdout.indexOf('Terraform v') === -1) {
+}
+
+exec('terraform -v', vCb);
+function vCb(err, vOut, stderr) {
+	handleDoubleErrorSource(err, stderr, 1);
+	if (vOut.indexOf('Terraform v') === -1) {
 		showError(
-			`Expected version information from 'terraform -v', instead received: ${stdout}`
+			`Expected version information from 'terraform -v', instead received: ${vOut}`
 		);
 		process.exit(2);
 	}
-});
+
+	exec('terraform version', versionCb);
+	function versionCb(err, versionOut, stderr) {
+		handleDoubleErrorSource(err, stderr, 3);
+		if (versionOut !== vOut) {
+			showError(
+				"Expected 'terraform -v' and 'terraform version' to have the same output; " +
+					`however, 'terraform -v' produces '${vOut}' and 'terraform version' ` +
+					`produces '${versionOut}'.`
+			);
+			process.exit(4);
+		}
+	}
+}

--- a/tests/installed-correctly.test.js
+++ b/tests/installed-correctly.test.js
@@ -4,15 +4,35 @@ function showError(msg) {
 	console.error(`Test 'installed-correctly' failed: ${msg}`);
 }
 
-execFile('yarn', ['start', '-v'], function(err, stdout) {
-	if (err) {
-		showError(err);
-		process.exit(1);
+function handleDoubleErrorSource(a, b, code) {
+	if (a || b) {
+		showError(a || b);
+		process.exit(code);
 	}
-	if (stdout.indexOf('Terraform v') === -1) {
+}
+
+execFile('yarn', ['start', '-v'], vCb);
+function vCb(err, stdout, stderr) {
+	handleDoubleErrorSource(err, stderr, 1);
+	const vStr = stdout.substr(stdout.indexOf('\n'));
+	if (vStr.indexOf('Terraform v') === -1) {
 		showError(
-			`Expected version information from 'terraform -v', instead received: ${stdout}`
+			`Expected version information from 'terraform -v', instead received: ${vStr}`
 		);
 		process.exit(2);
 	}
-});
+
+	execFile('yarn', ['start', 'version'], versionCb);
+	function versionCb(err, stodut, stderr) {
+		handleDoubleErrorSource(err, stderr, 3);
+		const versionStr = stdout.substr(stdout.indexOf('\n'));
+		if (versionStr !== vStr) {
+			showError(
+				"Expected 'terraform -v' and 'terraform version' to have the same output; " +
+					`however, 'terraform -v' produces '${vStr}' and 'terraform version' ` +
+					`produces '${versionStr}'.`
+			);
+			process.exit(4);
+		}
+	}
+}


### PR DESCRIPTION
Previously, tests only caught of 'terraform -v' was working; however,
this doesn't guarantee that passed arguments like 'terraform version'
would function as expected.

I've since added a new test which will compare 'terraform -v' and
'terraform version' and expect the outputs of the two commands to be the
same.