### PR TITLE
Fixed unexpected executable working directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terraform-npm",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "An NPM executable package for HashiCorp's Terraform.",
   "homepage": "https://www.npmjs.com/package/terraform-npm",
   "repository": "https://github.com/steven-xie/terraform-npm",

--- a/src/terraform-wrapper.js
+++ b/src/terraform-wrapper.js
@@ -4,10 +4,9 @@
 const { spawn } = require('child_process');
 const { resolve } = require('path');
 
-const command = process.platform === 'win32' ? 'terraform.exe' : './terraform';
-const terraform = spawn(command, process.argv.slice(2), {
-	cwd: resolve(__dirname, '..', 'tools')
-});
+const execName = process.platform === 'win32' ? 'terraform.exe' : './terraform';
+const command = resolve(__dirname, '..', 'tools', execName);
+const terraform = spawn(command, process.argv.slice(2), { cwd: process.cwd() });
 
 terraform.stdout.pipe(process.stdout);
 terraform.stderr.pipe(process.stderr);


### PR DESCRIPTION
Terraform used to start with a working directory based on its
installation location, which was undesirable; it now uses the working
directory of the Node process that started it.